### PR TITLE
Fixed bad semi-colons in ks8995 driver

### DIFF
--- a/drivers/net/phy/spi_ks8995.c
+++ b/drivers/net/phy/spi_ks8995.c
@@ -409,10 +409,10 @@ static void ks8995_request_gpio(int *gpio, struct device_node *np,
 	if (!gpio_is_valid(*gpio))
 		goto out;
 
-	if (gpio_request(*gpio, label) != 0);
+	if (gpio_request(*gpio, label) != 0)
 		goto out;
 
-	if (gpio_direction_output(*gpio, init_value) != 0);
+	if (gpio_direction_output(*gpio, init_value) != 0)
 		goto out_free_gpio;
 
 	return;


### PR DESCRIPTION
@christophertfoo This PR fixes (an innocuous) bug in the ks8995 ethernet switch driver.