### PR TITLE
Added a sysfs dev attr to track mmc bus timeouts

### DIFF
--- a/drivers/mmc/core/core.c
+++ b/drivers/mmc/core/core.c
@@ -159,18 +159,22 @@ void mmc_request_done(struct mmc_host *host, struct mmc_request *mrq)
 
 		led_trigger_event(host->led, LED_OFF);
 
-		if (mrq->sbc) {
-			pr_debug("%s: req done <CMD%u>: %d: %08x %08x %08x %08x\n",
+		if (mrq->sbc && mrq->sbc->error) {
+			host->timeouts++;
+			pr_warning("%s: sbc req done <CMD%u>: %d: %08x %08x %08x %08x\n",
 				mmc_hostname(host), mrq->sbc->opcode,
 				mrq->sbc->error,
 				mrq->sbc->resp[0], mrq->sbc->resp[1],
 				mrq->sbc->resp[2], mrq->sbc->resp[3]);
 		}
 
-		pr_debug("%s: req done (CMD%u): %d: %08x %08x %08x %08x\n",
-			mmc_hostname(host), cmd->opcode, err,
-			cmd->resp[0], cmd->resp[1],
-			cmd->resp[2], cmd->resp[3]);
+		if (err) {
+			host->timeouts++;
+			pr_warning("%s: req done (CMD%u): %d: %08x %08x %08x %08x\n",
+				mmc_hostname(host), cmd->opcode, err,
+				cmd->resp[0], cmd->resp[1],
+				cmd->resp[2], cmd->resp[3]);
+		}
 
 		if (mrq->data) {
 			pr_debug("%s:     %d bytes transferred: %d\n",

--- a/drivers/mmc/core/host.c
+++ b/drivers/mmc/core/host.c
@@ -46,9 +46,26 @@ static void mmc_host_classdev_release(struct device *dev)
 	kfree(host);
 }
 
+static ssize_t timeouts_show(struct device *dev, struct device_attribute *dev_attr,
+			char *buf)
+{
+	struct mmc_host *host = cls_dev_to_mmc_host(dev);
+
+	return sprintf(buf, "%d\n", host->timeouts);
+}
+
+static DEVICE_ATTR_RO(timeouts);
+
+static struct attribute *mmc_host_attrs[] = {
+	&dev_attr_timeouts.attr,
+	NULL,
+};
+ATTRIBUTE_GROUPS(mmc_host);
+
 static struct class mmc_host_class = {
 	.name		= "mmc_host",
 	.dev_release	= mmc_host_classdev_release,
+	.dev_groups	= mmc_host_groups,
 };
 
 int mmc_register_host_class(void)

--- a/include/linux/mmc/host.h
+++ b/include/linux/mmc/host.h
@@ -382,6 +382,7 @@ struct mmc_host {
 
 	int			dsr_req;	/* DSR value is valid */
 	u32			dsr;	/* optional driver stage (DSR) value */
+	unsigned int		timeouts;
 
 	unsigned long		private[0] ____cacheline_aligned;
 };


### PR DESCRIPTION
@christophertfoo This PR just adds a simple attribute to the sysfs tree for the mmc bus, so I can detect modem issues from userspace.